### PR TITLE
Fix: Update peerDependencies for React Native 0.76+ compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,6 @@
   "peerDependencies": {
     "expo": "*",
     "react": "*",
-    "react-native": "^0.74.3"
+    "react-native": ">=0.74.3"
   }
 }


### PR DESCRIPTION
This PR updates the peerDependencies in package.json to support newer versions of React Native (>= 0.74.3), including React Native 0.76.9 used in Expo SDK 52.
Tested the package in a real Expo project and confirmed full compatibility.

Let me know if anything else is needed

